### PR TITLE
fix/issues-annotation-types

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -82,7 +82,15 @@ type Activity struct {
 
 // Issue returns a issue found in sentry
 type Issue struct {
-	Annotations         *[]string               `json:"annotations,omitempty"`
+	// Annotations according to the sentry api schema is a []string.
+	//	However, the sentry api has been returning objects as well
+	// 	in json format, so we are using interface{} to handle any cases
+	//	  eg:
+	//	  {
+	//	    "url":"https://someurl.com",
+	//	    "displayName": "somename"
+	//	  }
+	Annotations         *[]interface{}          `json:"annotations,omitempty"`
 	AssignedTo          *InternalUser           `json:"assignedTo,omitempty"`
 	Activity            *[]Activity             `json:"activity,omitempty"`
 	Count               *string                 `json:"count,omitempty"`


### PR DESCRIPTION
According to https://github.com/getsentry/sentry/blob/24.7.1/api-docs/components/schemas/issue.json

the field annotations within issues should be an array of string
`"annotations": { "type": "array",
        "items": {
          "type": "string"
        }
      },`
 

However when querying some issues.annotations are object rather than string
 `"annotations": [
            {
                "url": "https://someurl.com",
                "displayName": "somename"
            }
        ],`

This result in the decodeOrError to fail Unmarshalling with the following error
`json: cannot unmarshal object into Go struct field Issue.annotations of type string`

Using annotations as []interface{} should allow Go to Unmarshall any array annotations no matter the type